### PR TITLE
Reserve rocket

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -114,15 +114,16 @@ body {
 }
 
 .rocket .content p span {
-  background-color: #18A2B8;
+  background-color: #18a2b8;
   color: #fff;
   padding: 4px 8px;
   font-size: 12px;
   margin-right: 8px;
   border-radius: 8px;
 }
-.rocket .content .btn-cancel{
-  border: 1px solid #B0B4B9;
+
+.rocket .content .btn-cancel {
+  border: 1px solid #b0b4b9;
   background-color: #fff;
-  color:#B0B4B9;
+  color: #b0b4b9;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -112,3 +112,17 @@ body {
   margin-top: 24px;
   background-color: #ededed;
 }
+
+.rocket .content p span {
+  background-color: #18A2B8;
+  color: #fff;
+  padding: 4px 8px;
+  font-size: 12px;
+  margin-right: 8px;
+  border-radius: 8px;
+}
+.rocket .content .btn-cancel{
+  border: 1px solid #B0B4B9;
+  background-color: #fff;
+  color:#B0B4B9;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -74,6 +74,7 @@ body {
 
 .rocket img {
   width: 300px;
+  height: 225px;
 }
 
 .rocket .content button {

--- a/src/Redux/Rockets/rockets.js
+++ b/src/Redux/Rockets/rockets.js
@@ -1,7 +1,8 @@
 import ApiClient from '../../service/Apiclient';
 
-const FETCHED_ROCKETS = 'spaceTravelers/rockets/FETCHED_ROCKETS';
 const FETCHING_ROCKETS = 'spaceTravelers/rockets/FETCHING_ROCKETS';
+const FETCHED_ROCKETS = 'spaceTravelers/rockets/FETCHED_ROCKETS';
+const RESERVE_ROCKET = 'spaceTravelers/rockets/RESERVE_ROCKET';
 
 export function fetchedRockets(rockets) {
   const formattedRockets = rockets.map((rocket) => ({
@@ -29,6 +30,10 @@ export const fetchRockets = () => async (dispatch) => {
     dispatch(fetchedRockets(response));
   }, 1000);
 };
+export const reserveRocket = (rocket) => ({
+  type: RESERVE_ROCKET,
+  rocket,
+});
 
 export default function reducer(state = [], action = {}) {
   switch (action.type) {
@@ -36,6 +41,10 @@ export default function reducer(state = [], action = {}) {
       return 'fetching Rockets...';
     case FETCHED_ROCKETS:
       return [...action.rockets];
+    case RESERVE_ROCKET:
+      return state.map(
+        (rocket) => (rocket.id !== action.rocket.id ? rocket : { ...rocket, reserved: true }),
+      );
     default:
       return state;
   }

--- a/src/Redux/Rockets/rockets.js
+++ b/src/Redux/Rockets/rockets.js
@@ -3,6 +3,7 @@ import ApiClient from '../../service/Apiclient';
 const FETCHING_ROCKETS = 'spaceTravelers/rockets/FETCHING_ROCKETS';
 const FETCHED_ROCKETS = 'spaceTravelers/rockets/FETCHED_ROCKETS';
 const RESERVE_ROCKET = 'spaceTravelers/rockets/RESERVE_ROCKET';
+const CANCEL_RESERVATION = 'spaceTravelers/rockets/CANCEL_RESERVATION';
 
 export function fetchedRockets(rockets) {
   const formattedRockets = rockets.map((rocket) => ({
@@ -35,6 +36,11 @@ export const reserveRocket = (rocket) => ({
   rocket,
 });
 
+export const cancelReservation = (rocket) => ({
+  type: CANCEL_RESERVATION,
+  rocket,
+});
+
 export default function reducer(state = [], action = {}) {
   switch (action.type) {
     case FETCHING_ROCKETS:
@@ -44,6 +50,10 @@ export default function reducer(state = [], action = {}) {
     case RESERVE_ROCKET:
       return state.map(
         (rocket) => (rocket.id !== action.rocket.id ? rocket : { ...rocket, reserved: true }),
+      );
+    case CANCEL_RESERVATION:
+      return state.map(
+        (rocket) => (rocket.id !== action.rocket.id ? rocket : { ...rocket, reserved: false }),
       );
     default:
       return state;

--- a/src/components/RocketItem.js
+++ b/src/components/RocketItem.js
@@ -30,6 +30,10 @@ function RocketItem(props) {
   const bookRocket = () => {
     dispatch(reserveRocket(rocket));
   };
+
+  const cancelReservation = () => {
+    dispatch(reserveRocket(rocket));
+  };
   return (
     <li className="rocket" key={id}>
       <div className="image-container">
@@ -37,8 +41,11 @@ function RocketItem(props) {
       </div>
       <div className="content">
         <h4>{name}</h4>
-        <p>{description}</p>
-        <button type="button" onClick={bookRocket}>Reserve Rocket</button>
+        <p>
+          {rocket.reserved ? <span>Reserved</span> : null}
+          {description}
+        </p>
+        {rocket.reserved ? <button type="button" onClick={cancelReservation}>Cancel Reservation</button> : <button type="button" onClick={bookRocket}>Reserve Rocket</button>}
       </div>
     </li>
   );

--- a/src/components/RocketItem.js
+++ b/src/components/RocketItem.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-import { reserveRocket } from '../Redux/Rockets/rockets';
+import { reserveRocket, cancelReservation } from '../Redux/Rockets/rockets';
 
 function RocketItem(props) {
   const dispatch = useDispatch();
@@ -31,8 +31,8 @@ function RocketItem(props) {
     dispatch(reserveRocket(rocket));
   };
 
-  const cancelReservation = () => {
-    dispatch(reserveRocket(rocket));
+  const cancelBooking = () => {
+    dispatch(cancelReservation(rocket));
   };
   return (
     <li className="rocket" key={id}>
@@ -45,7 +45,7 @@ function RocketItem(props) {
           {rocket.reserved ? <span>Reserved</span> : null}
           {description}
         </p>
-        {rocket.reserved ? <button type="button" onClick={cancelReservation}>Cancel Reservation</button> : <button type="button" onClick={bookRocket}>Reserve Rocket</button>}
+        {rocket.reserved ? <button type="button" onClick={cancelBooking}>Cancel Reservation</button> : <button type="button" onClick={bookRocket}>Reserve Rocket</button>}
       </div>
     </li>
   );

--- a/src/components/RocketItem.js
+++ b/src/components/RocketItem.js
@@ -15,13 +15,14 @@ function RocketItem(props) {
 
   RocketItem.propTypes = {
     rocket:
-      PropTypes.objectOf(
+      PropTypes.shape(
         {
           id: PropTypes.number,
           name: PropTypes.string,
           type: PropTypes.string,
-          flickrImages: PropTypes.array,
+          flickrImages: PropTypes.arrayOf(PropTypes.string),
           description: PropTypes.string,
+          reserved: PropTypes.bool,
         },
       ).isRequired,
 

--- a/src/components/RocketItem.js
+++ b/src/components/RocketItem.js
@@ -45,7 +45,7 @@ function RocketItem(props) {
           {rocket.reserved ? <span>Reserved</span> : null}
           {description}
         </p>
-        {rocket.reserved ? <button type="button" onClick={cancelBooking}>Cancel Reservation</button> : <button type="button" onClick={bookRocket}>Reserve Rocket</button>}
+        {rocket.reserved ? <button type="button" onClick={cancelBooking} className="btn-cancel">Cancel Reservation</button> : <button type="button" onClick={bookRocket}>Reserve Rocket</button>}
       </div>
     </li>
   );

--- a/src/components/RocketItem.js
+++ b/src/components/RocketItem.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { reserveRocket } from '../Redux/Rockets/rockets';
 
 function RocketItem(props) {
+  const dispatch = useDispatch();
   const { rocket } = props;
   const {
     id,
@@ -24,6 +27,9 @@ function RocketItem(props) {
 
   };
 
+  const bookRocket = () => {
+    dispatch(reserveRocket(rocket));
+  };
   return (
     <li className="rocket" key={id}>
       <div className="image-container">
@@ -32,7 +38,7 @@ function RocketItem(props) {
       <div className="content">
         <h4>{name}</h4>
         <p>{description}</p>
-        <button type="button">Reserve Rocket</button>
+        <button type="button" onClick={bookRocket}>Reserve Rocket</button>
       </div>
     </li>
   );

--- a/src/components/Rockets.js
+++ b/src/components/Rockets.js
@@ -13,10 +13,7 @@ function Rockets() {
   return (
     <ul className="rocket-list">
       { typeof (rockets) === 'string' ? (
-        <p>
-          {' '}
-          <LoadingRockets />
-        </p>
+        <LoadingRockets />
       ) : rockets.map((rocket) => <RocketItem rocket={rocket} key={rocket.id} />)}
     </ul>
   );


### PR DESCRIPTION
- When a user clicks the "Reserve rocket" button, action needs to be dispatched to update the store. You need to get the ID of the reserved rocket and update the state. Remember you mustn't mutate the state. Instead, you need to return a new state object with all rockets, but the selected rocket will have an extra key `reserved` with its value set to `true`. 
- Follow the same logic as with the "Reserve rocket" - but you need to set the `reserved` key to `false`.
- Rockets that have already been reserved should show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket" (as per design)